### PR TITLE
Query string types fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3593,9 +3593,9 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.11.0.tgz",
-      "integrity": "sha512-jS+me8X3OEGFTsF6kF+vUUMFG/d3WUCvD7bHhfZP5784nOq1pjj8yau/u86nfOncmcN6ZkSWKWkKAvv/MGxzLA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.11.1.tgz",
+      "integrity": "sha512-1ZvJOUl8ifkkBxu2ByVM/8GijMIPx+cef7u3yroO3Ogm4DOdZcF5dcrWTIlSHe3Pg/mtlt6/eFjObDfJureZZA==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "decode-uri-component": "^0.2.0",
     "encodeurl": "^1.0.2",
     "path-to-regexp": "^6.1.0",
-    "query-string": "^6.11.0",
+    "query-string": "^6.11.1",
     "typescript": "^3.8.2",
     "url-parse": "^1.4.7"
   },

--- a/src/tsurl.ts
+++ b/src/tsurl.ts
@@ -136,8 +136,7 @@ export class TSURL<
     const queryParams = queryString.parseUrl(url, {
       decode: this.options.decode,
       arrayFormat: this.options.queryArrayFormat,
-      // Cast necessary due to broken type in query-string
-      arrayFormatSeparator: this.options.queryArrayFormatSeparator as any,
+      arrayFormatSeparator: this.options.queryArrayFormatSeparator,
     }).query;
 
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,7 +135,7 @@ export interface TSURLOptions<
   decode?: boolean;
   normalize?: boolean;
   queryArrayFormat?: ParseOptions['arrayFormat'];
-  queryArrayFormatSeparator?: string;
+  queryArrayFormatSeparator?: ParseOptions['arrayFormatSeparator'];
   queryParams?: QueryParamsSchema<
     RequiredStringQueryKeys,
     RequiredNumberQueryKeys,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -425,7 +425,6 @@ export const constructQuery = (
   return queryString.stringify(filteredQueryParams, {
     encode,
     arrayFormat: queryArrayFormat,
-    // Cast necessary due to broken type in query-string
-    arrayFormatSeparator: queryArrayFormatSeparator as any,
+    arrayFormatSeparator: queryArrayFormatSeparator,
   });
 };


### PR DESCRIPTION
Installs latest `query-string` with correct type for `arrayFormatSeparator`, fixed in https://github.com/sindresorhus/query-string/pull/245