### PR TITLE
Base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,17 +120,44 @@ Returns `TSURL` with inferred keys for URL and query params.
 
 ### TSURL.getURLTemplate
 
-Returns a `path-to-regexp` compatible `string` from your defined schema.
+Returns a `path-to-regexp` compatible URL (including the `baseURL`) `string` from your defined schema.
 
 This method takes no arguments.
 
-### TSURL.construct
+### TSURL.getPathTemplate
 
-Returns a `string` URL/path.
+Returns a `path-to-regexp` compatible path (excluding the `baseURL`) `string` from your defined schema.
+
+This method takes no arguments.
+
+### TSURL.constructURL
+
+Returns a `string` URL (including the `baseURL`).
 
 This takes 2 arguments:
 
 - The URL params for this URL - an object with keys that match the required/optional URL params
+- The Query params for this URL - an object with keys that match the required/optional query params
+
+Note: this method will throw an error if you have not supplied required url/query params somehow (e.g. if you are not using type checking because your app is written in JavaScript, or you have cast your params to `any` in TypeScript).
+
+### TSURL.constructPath
+
+Returns a `string` path (excluding the `baseURL`).
+
+This takes 2 arguments:
+
+- The URL params for this URL - an object with keys that match the required/optional URL params
+- The Query params for this URL - an object with keys that match the required/optional query params
+
+Note: this method will throw an error if you have not supplied required url/query params somehow (e.g. if you are not using type checking because your app is written in JavaScript, or you have cast your params to `any` in TypeScript).
+
+### TSURL.constructQuery
+
+Returns a `string` of query params (prefixed with `?`) if any are provided.
+
+This takes 1 argument:
+
 - The Query params for this URL - an object with keys that match the required/optional query params
 
 Note: this method will throw an error if you have not supplied required query params somehow (e.g. if you are not using type checking because your app is written in JavaScript, or you have cast your params to `any` in TypeScript).

--- a/README.md
+++ b/README.md
@@ -105,6 +105,41 @@ interface Result {
 }
 ```
 
+## Example with `baseURL`
+
+If all of your requests are prefixed with a specific domain and or path you can provide a `baseURL` as an option which may include protocol, host, port, and base path.
+
+Note: the `baseURL` is not affected by the `normalize` option, except where a base URL with a trailing slash and a path with a leading slash would cause an unwanted double slash e.g. `baseURL: https://domain.com/api/` and path `/users` would output `https://domain.com/api/users` instead of `https://domain.com/api//users`.
+
+Example base URLs:
+
+```txt
+'domain.com'
+'https://domain.com'
+'http://localhost:1234'
+'/api/'
+'domain.com/api/'
+'https://domain.com/api'
+'http://localhost:1234/api'
+```
+
+Example output:
+
+```tsx
+const url = createTSURL(['/users', requiredString('userId')], {
+  baseURL: 'https://domain.com/api/'
+});
+
+url.getURLTemplate();
+// https://domain.com/api/users/:userId
+url.getPathTemplate();
+// /api/users/:userId
+url.constructURL({userId: 'ac'}, {});
+// https://domain.com/api/users/abc
+url.constructPath();
+// /api/users/abc
+```
+
 ## API
 
 ### createTSURL

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import { userDetailURL } from './urls';
 
 // ...
 
-<Route path={userDetailURL.getURLTemplate()} component={UserDetailPage} />;
+<Route path={userDetailURL.getPathTemplate()} component={UserDetailPage} />;
 ```
 
 This outputs a path with the same syntax as required by `react-router`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Until now you've probably been relying on keeping various bits of code in sync, or casting types `as` whatever you believe they should be to prevent errors when constructing, matching and or deconstructing URLs.
 
-TSURL prevents the need for you to worry about keeping your path templates in sync with your URL parameters, worries about accidental `//` in paths, missing URL parameters, bad protocols, unintentional or missing trailing slashes, URL encoding and decoding, query parameter construction/deconstruction, and type casting.
+TSURL prevents the need for you to worry about keeping your path templates in sync with your URL parameters, worries about accidental `//` in paths, missing URL parameters, unintentional or missing trailing slashes, URL encoding and decoding, query parameter construction/deconstruction, and type casting.
 
 Built on top of existing libraries that you're probably already using, such as `path-to-regexp`, `encodeurl` `query-string`, `url-parse`, etc, TSURL combines their functionality to provide a type safe interface for working with URLs and paths.
 
@@ -166,11 +166,11 @@ The options object is the second argument to the `createTSURL` function. All ava
 
 Options include:
 
-- `protocol` - `string | false` - protocol to enforce, or remove if set to `false`. Does nothing by default.
+- `baseURL` - `string` - base URL to prefix constructed URLs with (can include protocol, host, port, and base path e.g. `https://domain.com/api`).
 - `trailingSlash` - `boolean` - enforce or remove trailing slashes. Does nothing by default.
 - `encode` - `boolean` - whether to encode the URL when constructing. Defaults to `true`.
 - `decode` - `boolean` - whether to decode the URL when deconstructing. Default to `true`.
-- `normalize` - `boolean` - whether to strip **all** double slashes (`//`, including those that may be part of a protocol). Defaults to `true`. You should define an explicit `protocol` to avoid `//` being stripped from the protocol if your URL contains one.
+- `normalize` - `boolean` - whether to strip **all** double slashes from the path (`//`, excluding the `baseURL`, except where this causes multiple trailing slashes e.g. `createTSURL` with `baseURL: 'https://domain.com/api/'` and path parts `['/users']` will construct `https://domain.com/api/users`). Defaults to `true`.
 - `queryArrayFormat` - how to handle constructing/deconstructing query params that can have multiple values. This option is defined by the `query-string` package.
 - `queryArrayFormatSeparator` - `string` - the separator to use when `queryArrayFormat` is set to `separator`. Defaults to `,`.
 - `queryParams` - an array of [parameters](#parameters).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jakesidsmith/tsurl",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jakesidsmith/tsurl",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/decode-uri-component": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakesidsmith/tsurl",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Type safe URL construction and deconstruction",
   "main": "dist/index.js",
   "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,8 @@ import { TSURLOptions } from './types';
 
 export const MATCHES_MULTIPLE_SLASHES = /\/{2,}/g;
 export const MATCHES_MAYBE_TRAILING_SLASH = /\/?$/;
-export const MATCHES_MAYBE_PROTOCOL = /^(?:(?:[^/]+?:)?\/{0,2})?/;
+export const MATCHES_LEADING_SLASHES = /^\/*/;
+export const MATCHES_TRAILING_SLASHES = /\/*$/;
 
 export const DEFAULT_OPTIONS: Omit<
   TSURLOptions<readonly never[]>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,7 @@ export type QueryParamsSchema = ReadonlyArray<
 >;
 
 export interface TSURLOptions<Q extends QueryParamsSchema> {
-  protocol?: string | false;
+  baseURL?: string;
   trailingSlash?: boolean;
   encode?: boolean;
   decode?: boolean;

--- a/tests/params.ts
+++ b/tests/params.ts
@@ -154,13 +154,13 @@ describe('params', () => {
     );
 
     // @tsassert: (urlParams: { required: string; } & {} & {} & { optional?: string | undefined; } & {} & {}, queryParams: { requiredQ: string; } & {} & {} & { optionalQ?: string | undefined; } & {} & {} & {} & {} & {} & {} & {} & {}) => string
-    const construct = url.construct;
+    const constructPath = url.constructPath;
 
-    expect(construct({ required: 'a' }, { requiredQ: 'c' })).toBe(
+    expect(constructPath({ required: 'a' }, { requiredQ: 'c' })).toBe(
       '/api/example/a/test/?requiredQ=c'
     );
     expect(
-      construct(
+      constructPath(
         { required: 'a', optional: 'b' },
         { requiredQ: 'c', optionalQ: 'd' }
       )
@@ -207,13 +207,16 @@ describe('params', () => {
     );
 
     // @tsassert: (urlParams: {} & { required: number; } & {} & {} & { optional?: number | undefined; } & {}, queryParams: {} & { requiredQ: number; } & {} & {} & { optionalQ?: number | undefined; } & {} & {} & {} & {} & {} & {} & {}) => string
-    const construct = url.construct;
+    const constructPath = url.constructPath;
 
-    expect(construct({ required: 1 }, { requiredQ: 3 })).toBe(
+    expect(constructPath({ required: 1 }, { requiredQ: 3 })).toBe(
       '/api/example/1/test/?requiredQ=3'
     );
     expect(
-      construct({ required: 1, optional: 2 }, { requiredQ: 3, optionalQ: 4 })
+      constructPath(
+        { required: 1, optional: 2 },
+        { requiredQ: 3, optionalQ: 4 }
+      )
     ).toBe('/api/example/1/test/2?optionalQ=4&requiredQ=3');
 
     // @tsassert: (url: string) => { urlParams: {} & { required: number; } & {} & {} & { optional?: number | undefined; } & {}; queryParams: {} & { requiredQ: number; } & {} & {} & { optionalQ?: number | undefined; } & ... 6 more ... & {}; }
@@ -260,13 +263,13 @@ describe('params', () => {
     );
 
     // @tsassert: (urlParams: {} & {} & { required: boolean; } & {} & {} & { optional?: boolean | undefined; }, queryParams: {} & {} & { requiredQ: boolean; } & {} & {} & { optionalQ?: boolean | undefined; } & {} & {} & {} & {} & {} & {}) => string
-    const construct = url.construct;
+    const constructPath = url.constructPath;
 
-    expect(construct({ required: true }, { requiredQ: true })).toBe(
+    expect(constructPath({ required: true }, { requiredQ: true })).toBe(
       '/api/example/true/test/?requiredQ=true'
     );
     expect(
-      construct(
+      constructPath(
         { required: true, optional: false },
         { requiredQ: true, optionalQ: false }
       )
@@ -308,13 +311,13 @@ describe('params', () => {
     });
 
     // @tsassert: (urlParams: {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & { requiredQ: readonly string[]; } & {} & {} & { optionalQ?: readonly string[] | undefined; } & {} & {}) => string
-    const construct1 = url1.construct;
+    const constructPath1 = url1.constructPath;
 
-    expect(construct1({}, { requiredQ: ['a', 'b'] })).toBe(
+    expect(constructPath1({}, { requiredQ: ['a', 'b'] })).toBe(
       '/api/example?requiredQ=a&requiredQ=b'
     );
     expect(
-      construct1({}, { requiredQ: ['a', 'b'], optionalQ: ['c', 'd'] })
+      constructPath1({}, { requiredQ: ['a', 'b'], optionalQ: ['c', 'd'] })
     ).toBe('/api/example?optionalQ=c&optionalQ=d&requiredQ=a&requiredQ=b');
 
     // @tsassert: (url: string) => { urlParams: {} & {} & {} & {} & {} & {}; queryParams: {} & {} & {} & {} & {} & {} & { requiredQ: readonly string[]; } & {} & {} & { optionalQ?: readonly string[] | undefined; } & {} & {}; }
@@ -348,13 +351,13 @@ describe('params', () => {
     });
 
     // @tsassert: (urlParams: {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & { requiredQ: readonly string[]; } & {} & {} & { optionalQ?: readonly string[] | undefined; } & {} & {}) => string
-    const construct2 = url2.construct;
+    const constructPath2 = url2.constructPath;
 
-    expect(construct2({}, { requiredQ: ['a', 'b'] })).toBe(
+    expect(constructPath2({}, { requiredQ: ['a', 'b'] })).toBe(
       '/api/example?requiredQ=a,b'
     );
     expect(
-      construct2({}, { requiredQ: ['a', 'b'], optionalQ: ['c', 'd'] })
+      constructPath2({}, { requiredQ: ['a', 'b'], optionalQ: ['c', 'd'] })
     ).toBe('/api/example?optionalQ=c,d&requiredQ=a,b');
 
     // @tsassert: (url: string) => { urlParams: {} & {} & {} & {} & {} & {}; queryParams: {} & {} & {} & {} & {} & {} & { requiredQ: readonly string[]; } & {} & {} & { optionalQ?: readonly string[] | undefined; } & {} & {}; }
@@ -385,12 +388,12 @@ describe('params', () => {
     });
 
     // @tsassert: (urlParams: {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly number[]; } & {} & {} & { optionalQ?: readonly number[] | undefined; } & {}) => string
-    const construct1 = url1.construct;
+    const constructPath1 = url1.constructPath;
 
-    expect(construct1({}, { requiredQ: [1, 2] })).toBe(
+    expect(constructPath1({}, { requiredQ: [1, 2] })).toBe(
       '/api/example?requiredQ=1&requiredQ=2'
     );
-    expect(construct1({}, { requiredQ: [1, 2], optionalQ: [3, 4] })).toBe(
+    expect(constructPath1({}, { requiredQ: [1, 2], optionalQ: [3, 4] })).toBe(
       '/api/example?optionalQ=3&optionalQ=4&requiredQ=1&requiredQ=2'
     );
 
@@ -425,12 +428,12 @@ describe('params', () => {
     });
 
     // @tsassert: (urlParams: {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly number[]; } & {} & {} & { optionalQ?: readonly number[] | undefined; } & {}) => string
-    const construct2 = url2.construct;
+    const constructPath2 = url2.constructPath;
 
-    expect(construct2({}, { requiredQ: [1, 2] })).toBe(
+    expect(constructPath2({}, { requiredQ: [1, 2] })).toBe(
       '/api/example?requiredQ=1,2'
     );
-    expect(construct2({}, { requiredQ: [1, 2], optionalQ: [3, 4] })).toBe(
+    expect(constructPath2({}, { requiredQ: [1, 2], optionalQ: [3, 4] })).toBe(
       '/api/example?optionalQ=3,4&requiredQ=1,2'
     );
 
@@ -462,13 +465,13 @@ describe('params', () => {
     });
 
     // @tsassert: (urlParams: {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly boolean[]; } & {} & {} & { optionalQ?: readonly boolean[] | undefined; }) => string
-    const construct1 = url1.construct;
+    const constructPath1 = url1.constructPath;
 
-    expect(construct1({}, { requiredQ: [true, false] })).toBe(
+    expect(constructPath1({}, { requiredQ: [true, false] })).toBe(
       '/api/example?requiredQ=true&requiredQ=false'
     );
     expect(
-      construct1({}, { requiredQ: [true, false], optionalQ: [true, false] })
+      constructPath1({}, { requiredQ: [true, false], optionalQ: [true, false] })
     ).toBe(
       '/api/example?optionalQ=true&optionalQ=false&requiredQ=true&requiredQ=false'
     );
@@ -506,13 +509,13 @@ describe('params', () => {
     });
 
     // @tsassert: (urlParams: {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly boolean[]; } & {} & {} & { optionalQ?: readonly boolean[] | undefined; }) => string
-    const construct2 = url2.construct;
+    const constructPath2 = url2.constructPath;
 
-    expect(construct2({}, { requiredQ: [true, false] })).toBe(
+    expect(constructPath2({}, { requiredQ: [true, false] })).toBe(
       '/api/example?requiredQ=true,false'
     );
     expect(
-      construct2({}, { requiredQ: [true, false], optionalQ: [true, false] })
+      constructPath2({}, { requiredQ: [true, false], optionalQ: [true, false] })
     ).toBe('/api/example?optionalQ=true,false&requiredQ=true,false');
 
     // @tsassert: (url: string) => { urlParams: {} & {} & {} & {} & {} & {}; queryParams: {} & {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly boolean[]; } & {} & {} & { optionalQ?: readonly boolean[] | undefined; }; }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -10,7 +10,8 @@ import {
   requiredString,
 } from '../src';
 import {
-  constructPath,
+  constructPathAndMaybeEncode,
+  constructURLAndMaybeEncode,
   constructQuery,
   serializeQueryParams,
   serializeURLParams,
@@ -77,11 +78,19 @@ describe('serializeQueryParams', () => {
   });
 });
 
-describe('constructPath', () => {
+describe('constructPathAndMaybeEncode', () => {
   it('should throw if a required URL param is undefined', () => {
-    expect(() => constructPath({}, [requiredString('test')], {})).toThrow(
-      'not provided'
-    );
+    expect(() =>
+      constructPathAndMaybeEncode({}, [requiredString('test')], {})
+    ).toThrow('not provided');
+  });
+});
+
+describe('constructURLAndMaybeEncode', () => {
+  it('should throw if a required URL param is undefined', () => {
+    expect(() =>
+      constructURLAndMaybeEncode({}, [requiredString('test')], {})
+    ).toThrow('not provided');
   });
 });
 


### PR DESCRIPTION
Breaking changes: 
- `deconstruct` now deconstructs based on path template instead of full URL template
- Removed `protocol` option in favor of `baseURL`

All changes:
- Remove `protocol` option
- Add `baseURL` option
- Expose `constructQuery`, `constructPath` and `constructURL` methods
- Expose `getPathTemplate` and `getURLTemplate` methods
- `deconstruct` method now deconstructs only from the path template

Note: `normalize` option will only affect the path and trailing slashes of `baseURL` e.g. `https://domain.com/api/` with path `/users//thing` becomes `https://domain.com/api/users/thing` instead of `https://domain.com/api//users//thing`

Will bump the version to `2.0.0` after approval.