### PR TITLE
TSURL groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ url.getURLTemplate();
 // https://domain.com/api/users/:userId
 url.getPathTemplate();
 // /api/users/:userId
-url.constructURL({userId: 'ac'}, {});
+url.constructURL({ userId: 'abc' }, {});
 // https://domain.com/api/users/abc
 url.constructPath();
 // /api/users/abc

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ interface Result {
 }
 ```
 
-## Example with `baseURL`
+## Example with `baseURL`/`basePath`
 
-If all of your requests are prefixed with a specific domain and or path you can provide a `baseURL` as an option which may include protocol, host, port, and base path.
+If all of your requests are prefixed with a specific domain and or path you can provide a `baseURL` and or `basePath` as an option. The `baseURL` may include protocol, host, port, and base path, but I'd recommend using `basePath` for paths in most circumstances.
 
 Note: the `baseURL` is not affected by the `normalize` option, except where a base URL with a trailing slash and a path with a leading slash would cause an unwanted double slash e.g. `baseURL: https://domain.com/api/` and path `/users` would output `https://domain.com/api/users` instead of `https://domain.com/api//users`.
 
@@ -127,7 +127,8 @@ Example output:
 
 ```tsx
 const url = createTSURL(['/users', requiredString('userId')], {
-  baseURL: 'https://domain.com/api/'
+  baseURL: 'https://domain.com/',
+  basePath: '/api',
 });
 
 url.getURLTemplate();
@@ -138,6 +139,34 @@ url.constructURL({ userId: 'abc' }, {});
 // https://domain.com/api/users/abc
 url.constructPath();
 // /api/users/abc
+```
+
+## Example using groups
+
+If we have our API running on a different domain we can use groups to pre-fill `baseURL`, `basePath` (and or any other options) for client and API URLs.
+
+```ts
+const api = createTSURLGroup({
+  baseUrl: 'https://server.com',
+  basePath: '/api',
+  trailingSlash: true,
+});
+
+const API_URLS = {
+  users: api.createTSURL(['users']),
+  user: api.createTSURL(['users', requiredString('userId')]),
+  userImages: api.createTSURL(['users', requiredString('userId'), 'images']),
+};
+
+const client = createTSURLGroup({
+  baseUrl: 'https://client.com',
+  trailingSlash: false,
+});
+
+const CLIENT_URLS = {
+  users: client.createTSURL(['users']),
+  user: client.createTSURL(['users', requiredString('userId')]),
+};
 ```
 
 ## API
@@ -152,6 +181,18 @@ This takes 1 or 2 arguments:
 - An options object (optional) - `Options` - see [Options](#options) for more info
 
 Returns `TSURL` with inferred keys for URL and query params.
+
+### createTSURLGroup
+
+The `createTSURLGroup` function, returns an object with a `createTSURL` function.
+
+This takes 1 argument:
+
+- An options object - `Options` - see [Options](#options) for more info
+
+#### group.createTSURL
+
+As with the named/default exported `createTSURL`, but inherits options from the group.
 
 ### TSURL.getURLTemplate
 
@@ -229,6 +270,7 @@ The options object is the second argument to the `createTSURL` function. All ava
 Options include:
 
 - `baseURL` - `string` - base URL to prefix constructed URLs with (can include protocol, host, port, and base path e.g. `https://domain.com/api`).
+- `basePath` - `string | readonly string[]` - path to prefix the schema (path parts) for all URLs created with the group.
 - `trailingSlash` - `boolean` - enforce or remove trailing slashes. Does nothing by default.
 - `encode` - `boolean` - whether to encode the URL when constructing. Defaults to `true`.
 - `decode` - `boolean` - whether to decode the URL when deconstructing. Default to `true`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jakesidsmith/tsurl",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jakesidsmith/tsurl",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/decode-uri-component": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakesidsmith/tsurl",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Type safe URL construction and deconstruction",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "dist": "rm -rf dist && tsc --project tsconfig.dist.json",
-    "prettier": "prettier --write '**/*.{ts,tsx,js,jsx,json}'",
-    "prettier-check": "prettier --check '**/*.{ts,tsx,js,jsx,json}'",
+    "prettier": "prettier --write '**/*.{ts,tsx,js,jsx,json,md}'",
+    "prettier-check": "prettier --check '**/*.{ts,tsx,js,jsx,json,md}'",
     "lint-js": "eslint '**/*.{ts,tsx,js,jsx}'",
     "typecheck": "tsc --project tsconfig.json --noEmit && tsassert",
     "lint": "npm run prettier-check && npm run typecheck && npm run lint-js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,22 @@ const createTSURL = <
   return new TSURL(schema, options);
 };
 
-export { createTSURL };
+const createTSURLGroup = (
+  options: Omit<TSURLOptions<never>, 'queryParams'>
+) => {
+  const createTSURL = <
+    S extends URLParamsSchema = readonly never[],
+    Q extends QueryParamsSchema = readonly never[]
+  >(
+    schema: S,
+    optionOverrides: TSURLOptions<Q> = DEFAULT_OPTIONS
+  ) => {
+    return new TSURL(schema, { ...options, ...optionOverrides });
+  };
+
+  return { createTSURL };
+};
+
+export { createTSURL, createTSURLGroup };
 
 export default createTSURL;

--- a/src/tsurl.ts
+++ b/src/tsurl.ts
@@ -34,7 +34,11 @@ export class TSURL<
       // We cast a default queryParams so that the output type of deconstruct doesn't have to handle it potentially being undefined
       queryParams: options?.queryParams ?? ([] as unknown as Q),
     };
-    this.schema = schema;
+    const schemaPrefix =
+      typeof options?.basePath !== 'undefined'
+        ? ([] as readonly string[]).concat(options.basePath)
+        : [];
+    this.schema = [...schemaPrefix, ...schema] as unknown as S;
   }
 
   public constructQuery = (queryParams: InferQueryParams<Q>) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export type QueryParamsSchema = ReadonlyArray<
 
 export interface TSURLOptions<Q extends QueryParamsSchema> {
   baseURL?: string;
+  basePath?: string | readonly string[];
   trailingSlash?: boolean;
   encode?: boolean;
   decode?: boolean;

--- a/tests/groups.ts
+++ b/tests/groups.ts
@@ -1,0 +1,32 @@
+import { createTSURLGroup, requiredString } from '../src';
+
+describe('createTSURLGroup', () => {
+  it('should return an object of functions that allow creating TSURLs with some options pre-configured', () => {
+    const group = createTSURLGroup({
+      baseURL: 'https://domain.com',
+      basePath: '/api',
+      trailingSlash: true,
+    });
+
+    expect(group).toEqual({
+      createTSURL: expect.any(Function),
+    });
+  });
+
+  describe('createTSURL', () => {
+    it('should construct a TSURL that extends the group config', () => {
+      const group = createTSURLGroup({
+        baseURL: 'https://domain.com',
+        basePath: '/api',
+        trailingSlash: true,
+      });
+
+      const user = group.createTSURL(['users', requiredString('userId')]);
+
+      expect(user.getPathTemplate()).toBe('/api/users/:userId/');
+      expect(user.getURLTemplate()).toBe(
+        'https://domain.com/api/users/:userId/'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Resolves #25 

- Add `createTSURLGroup` function to pre-fill options for a collection of URLs
- Add `basePath` option so that get path/URL functions can prefix with normalized paths