### PR TITLE
Allow sub-paths when deconstructing

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ url.constructPath({ userId: 'abc' }, {});
 url.constructPath({ userId: 'abc', splat: ['posts', '123'] }, {});
 // returns '/api/user/abc/posts/123'
 
-url.deconstruct('https://server.com/user/abc');
+url.deconstruct('https://server.com/api/user/abc');
 // returns { urlParams: { userId: 'abc', splat: undefined }, queryParams: {} }
 
-url.deconstruct('https://server.com/user/123/posts/123');
+url.deconstruct('https://server.com/api/user/123/posts/123');
 // returns { urlParams: { userId: '123', splat: ['posts', '123'] }, queryParams: {} }
 ```
 
@@ -204,10 +204,10 @@ const url = createTSURL(['user', requiredString('userId')], {
   trailingSlash: false,
 });
 
-url.deconstruct('https://server.com/user/123/posts/123');
+url.deconstruct('https://server.com/api/user/123/posts/123');
 // throws an error
 
-url.deconstruct('https://server.com/user/123/posts/123', {
+url.deconstruct('https://server.com/api/user/123/posts/123', {
   allowSubPaths: true,
 });
 // returns { urlParams: { userId: '123' }, queryParams: {} }

--- a/README.md
+++ b/README.md
@@ -286,9 +286,10 @@ Note: this method will throw an error if you have not supplied required query pa
 
 Returns the URL and query params extracted from a string URL/path.
 
-This takes a single argument:
+This takes 1 or 2 arguments:
 
 - URL/path - `string` - the URL you wish to extract parameters from
+- An options object (optional) - `Options` - see [Deconstruct Options](#deconstructoptions) for more info
 
 Returns an object with `urlParams` and `queryParams` keys. Both of these keys will be objects containing the parameters you defined in your schema e.g.
 
@@ -322,6 +323,14 @@ Options include:
 - `queryArrayFormat` - how to handle constructing/deconstructing query params that can have multiple values. This option is defined by the `query-string` package.
 - `queryArrayFormatSeparator` - `string` - the separator to use when `queryArrayFormat` is set to `separator`. Defaults to `,`.
 - `queryParams` - an array of [parameters](#parameters).
+
+### Deconstruct Options
+
+This is the second argument to the `deconstruct` function.
+
+Options include:
+
+- `allowSubPaths` - `boolean` - whether the deconstruction will allow sub-paths (stuff that appears after your defined template) in the provided URL/path
 
 ### Parameters
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This outputs a path with the same syntax as required by `react-router`.
 Now, if you wanted to navigate to this URL you'd probably previously have used string concatenation, a template string, or `path-to-regexp` to construct the path, but none of these offer type safety. Instead now you can use your TSURL instance to construct a path. It will enforce that you provide a string for the user's ID.
 
 ```ts
-const whereWeWantToGo = userDetailURL.construct({ id: 'abc' }, {});
+const whereWeWantToGo = userDetailURL.constructPath({ id: 'abc' }, {});
 ```
 
 This will output `/users/abc/` exactly as we'd expect, but would fail type checks if the `id` key was missing from the URL parameters object. The second argument is the query params object, but since we don't need any, we've just provided an empty object. Note: this method will throw an error if you somehow fail to supply the user id e.g. not using type checking, or cast your params to `any`.
@@ -88,11 +88,11 @@ const userListURL = createTSURL(['/users'], {
 Here we've constructed a TSURL instance that will not only enforce that we provide a number (or nothing as we may not want to define the page number for the first page) when constructing a URL for this route, but also will give us sensible types for the parameters when deconstructing.
 
 ```ts
-userListURL.construct({}, {}); // Is fine because page is optional
-userListURL.construct({}, { page: 2 }); // Is fine because page should be a number
+userListURL.constructPath({}, {}); // Is fine because page is optional
+userListURL.constructPath({}, { page: 2 }); // Is fine because page should be a number
 
-userListURL.construct({}, { page: '2' }); // Disallowed by types (would error)
-userListURL.construct({}, { page: null }); // Disallowed by types (would error)
+userListURL.constructPath({}, { page: '2' }); // Disallowed by types (would error)
+userListURL.constructPath({}, { page: null }); // Disallowed by types (would error)
 
 // The below deconstruct will handle casting the page query param to a number if found
 userListURL.deconstruct(window.location.href);
@@ -137,7 +137,7 @@ url.getPathTemplate();
 // /api/users/:userId
 url.constructURL({ userId: 'abc' }, {});
 // https://domain.com/api/users/abc
-url.constructPath();
+url.constructPath({ userId: 'abc' }, {});
 // /api/users/abc
 ```
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,26 @@ url.deconstruct('https://server.com/user/123/posts/123');
 // returns { urlParams: { userId: '123', splat: ['posts', '123'] }, queryParams: {} }
 ```
 
+## Allow sub-paths when you don't want to match a splat
+
+In some cases you want your URL templates to match a specific template, but when deconstructing you don't mind if the URL/path contains additional sub-paths. In these cases you can pass the `allowSubPaths` option to the deconstruct method.
+
+```ts
+const url = createTSURL(['user', requiredString('userId')], {
+  baseUrl: 'https://server.com',
+  basePath: '/api',
+  trailingSlash: false,
+});
+
+url.deconstruct('https://server.com/user/123/posts/123');
+// throws an error
+
+url.deconstruct('https://server.com/user/123/posts/123', {
+  allowSubPaths: true,
+});
+// returns { urlParams: { userId: '123' }, queryParams: {} }
+```
+
 ## API
 
 ### createTSURL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jakesidsmith/tsurl",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jakesidsmith/tsurl",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@types/decode-uri-component": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakesidsmith/tsurl",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Type safe URL construction and deconstruction",
   "main": "dist/index.js",
   "scripts": {

--- a/src/tsurl.ts
+++ b/src/tsurl.ts
@@ -104,7 +104,7 @@ export class TSURL<
     const parsed = urlParse(this.options.decode ? decodeUrl(url) : url, false);
 
     const urlMatch = match<
-      Record<string, string | undefined | null | ReadonlyArray<string>>
+      Record<string, string | undefined | null | readonly string[]>
     >(pathTemplate)(parsed.pathname);
 
     if (!urlMatch) {

--- a/src/tsurl.ts
+++ b/src/tsurl.ts
@@ -6,6 +6,7 @@ import urlParse from 'url-parse';
 import { DEFAULT_OPTIONS } from './constants';
 import { PartType } from './params';
 import {
+  DeconstructOptions,
   InferQueryParams,
   InferURLParams,
   QueryParamsSchema,
@@ -90,8 +91,16 @@ export class TSURL<
     return `${url}${this.constructQuery(queryParams)}`;
   };
 
-  public deconstruct = (url: string) => {
-    const pathTemplate = this.getPathTemplate();
+  public deconstruct = (
+    url: string,
+    deconstructOptions?: DeconstructOptions
+  ) => {
+    const pathTemplate = constructPathAndMaybeEncode(
+      this.getURLParams(),
+      this.schema,
+      this.options,
+      deconstructOptions
+    );
     const parsed = urlParse(this.options.decode ? decodeUrl(url) : url, false);
 
     const urlMatch = match<

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,7 +144,6 @@ export type InferQueryParams<Q extends QueryParamsSchema = readonly never[]> =
           | OptionalStringArray<infer Name>
           | OptionalNumberArray<infer Name>
           | OptionalBooleanArray<infer Name>
-          | Splat<infer Name>
           ? Name
           : never]?: V extends OptionalString<string>
           ? string
@@ -152,8 +151,6 @@ export type InferQueryParams<Q extends QueryParamsSchema = readonly never[]> =
           ? number
           : V extends OptionalBoolean<string>
           ? boolean
-          : V extends Splat<string>
-          ? readonly string[]
           : V extends OptionalStringArray<string>
           ? readonly string[]
           : V extends OptionalNumberArray<string>

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,59 +81,85 @@ export interface DeconstructOptions {
 export type InferURLParams<S extends URLParamsSchema = readonly never[]> =
   S extends readonly (infer V)[]
     ? {
-        [P in V extends RequiredString<infer Name> ? Name : never]: string;
+        [P in V extends
+          | RequiredString<infer Name>
+          | RequiredNumber<infer Name>
+          | RequiredBoolean<infer Name>
+          ? Name
+          : never]: V extends RequiredString<string>
+          ? string
+          : V extends RequiredNumber<string>
+          ? number
+          : V extends RequiredBoolean<string>
+          ? boolean
+          : never;
       } & {
-        [P in V extends RequiredNumber<infer Name> ? Name : never]: number;
-      } & {
-        [P in V extends RequiredBoolean<infer Name> ? Name : never]: boolean;
-      } & {
-        [P in V extends OptionalString<infer Name> ? Name : never]?: string;
-      } & {
-        [P in V extends OptionalNumber<infer Name> ? Name : never]?: number;
-      } & {
-        [P in V extends OptionalBoolean<infer Name> ? Name : never]?: boolean;
-      } & {
-        [P in V extends Splat<infer Name> ? Name : never]?: readonly string[];
+        [P in V extends
+          | OptionalString<infer Name>
+          | OptionalNumber<infer Name>
+          | OptionalBoolean<infer Name>
+          | Splat<infer Name>
+          ? Name
+          : never]?: V extends OptionalString<string>
+          ? string
+          : V extends OptionalNumber<string>
+          ? number
+          : V extends OptionalBoolean<string>
+          ? boolean
+          : V extends Splat<string>
+          ? readonly string[]
+          : never;
       }
     : never;
 
 export type InferQueryParams<Q extends QueryParamsSchema = readonly never[]> =
   Q extends readonly (infer V)[]
     ? {
-        [P in V extends RequiredString<infer Name> ? Name : never]: string;
-      } & {
-        [P in V extends RequiredNumber<infer Name> ? Name : never]: number;
-      } & {
-        [P in V extends RequiredBoolean<infer Name> ? Name : never]: boolean;
-      } & {
-        [P in V extends OptionalString<infer Name> ? Name : never]?: string;
-      } & {
-        [P in V extends OptionalNumber<infer Name> ? Name : never]?: number;
-      } & {
-        [P in V extends OptionalBoolean<infer Name> ? Name : never]?: boolean;
-      } & {
-        [P in V extends RequiredStringArray<infer Name>
+        [P in V extends
+          | RequiredString<infer Name>
+          | RequiredNumber<infer Name>
+          | RequiredBoolean<infer Name>
+          | RequiredStringArray<infer Name>
+          | RequiredNumberArray<infer Name>
+          | RequiredBooleanArray<infer Name>
           ? Name
-          : never]: readonly string[];
+          : never]: V extends RequiredString<string>
+          ? string
+          : V extends RequiredNumber<string>
+          ? number
+          : V extends RequiredBoolean<string>
+          ? boolean
+          : V extends RequiredStringArray<string>
+          ? readonly string[]
+          : V extends RequiredNumberArray<string>
+          ? readonly number[]
+          : V extends RequiredBooleanArray<string>
+          ? readonly boolean[]
+          : never;
       } & {
-        [P in V extends RequiredNumberArray<infer Name>
+        [P in V extends
+          | OptionalString<infer Name>
+          | OptionalNumber<infer Name>
+          | OptionalBoolean<infer Name>
+          | OptionalStringArray<infer Name>
+          | OptionalNumberArray<infer Name>
+          | OptionalBooleanArray<infer Name>
+          | Splat<infer Name>
           ? Name
-          : never]: readonly number[];
-      } & {
-        [P in V extends RequiredBooleanArray<infer Name>
-          ? Name
-          : never]: readonly boolean[];
-      } & {
-        [P in V extends OptionalStringArray<infer Name>
-          ? Name
-          : never]?: readonly string[];
-      } & {
-        [P in V extends OptionalNumberArray<infer Name>
-          ? Name
-          : never]?: readonly number[];
-      } & {
-        [P in V extends OptionalBooleanArray<infer Name>
-          ? Name
-          : never]?: readonly boolean[];
+          : never]?: V extends OptionalString<string>
+          ? string
+          : V extends OptionalNumber<string>
+          ? number
+          : V extends OptionalBoolean<string>
+          ? boolean
+          : V extends Splat<string>
+          ? readonly string[]
+          : V extends OptionalStringArray<string>
+          ? readonly string[]
+          : V extends OptionalNumberArray<string>
+          ? readonly number[]
+          : V extends OptionalBooleanArray<string>
+          ? readonly boolean[]
+          : never;
       }
     : never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,10 @@ export interface TSURLOptions<Q extends QueryParamsSchema> {
   queryParams?: Q;
 }
 
+export interface DeconstructOptions {
+  allowSubPaths?: boolean;
+}
+
 export type InferURLParams<S extends URLParamsSchema = readonly never[]> =
   S extends readonly (infer V)[]
     ? {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,7 @@ export type AnyPart<T extends string> =
   | OptionalPart<T>
   | Splat<T>;
 
-export type URLParamsSchema = ReadonlyArray<
+export type URLParamsSchema = readonly (
   | string
   | RequiredString<string>
   | RequiredNumber<string>
@@ -45,9 +45,9 @@ export type URLParamsSchema = ReadonlyArray<
   | OptionalNumber<string>
   | OptionalBoolean<string>
   | Splat<string>
->;
+)[];
 
-export type QueryParamsSchema = ReadonlyArray<
+export type QueryParamsSchema = readonly (
   | RequiredString<string>
   | RequiredNumber<string>
   | RequiredBoolean<string>
@@ -60,7 +60,7 @@ export type QueryParamsSchema = ReadonlyArray<
   | OptionalStringArray<string>
   | OptionalNumberArray<string>
   | OptionalBooleanArray<string>
->;
+)[];
 
 export interface TSURLOptions<Q extends QueryParamsSchema> {
   baseURL?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -362,14 +362,14 @@ export const constructQuery = <Q extends QueryParamsSchema = readonly never[]>(
     | readonly boolean[]
     | readonly number[]
   >,
-  queryParamsShema: Q,
+  queryParamsSchema: Q,
   options: TSURLOptions<Q>
 ) => {
   const { encode, queryArrayFormat, queryArrayFormatSeparator } = options;
 
   const filteredQueryParams: Record<string, unknown> = {};
 
-  queryParamsShema.forEach((part) => {
+  queryParamsSchema.forEach((part) => {
     const value = queryParams[part.name];
 
     if (typeof value !== 'undefined') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,7 @@ import {
 } from './params';
 import {
   AnyPart,
+  DeconstructOptions,
   InferQueryParams,
   InferURLParams,
   QueryParamsSchema,
@@ -246,7 +247,8 @@ export const serializeQueryParams = <
 export const constructPath = <S extends URLParamsSchema = readonly never[]>(
   urlParams: Record<string, string | boolean | number | readonly string[]>,
   urlParamsSchema: S,
-  options: Omit<TSURLOptions<readonly never[]>, 'queryParams'>
+  options: Omit<TSURLOptions<readonly never[]>, 'queryParams'>,
+  deconstructOptions?: DeconstructOptions
 ) => {
   const { trailingSlash, normalize } = options;
 
@@ -286,6 +288,14 @@ export const constructPath = <S extends URLParamsSchema = readonly never[]>(
     path = path.replace(MATCHES_MAYBE_TRAILING_SLASH, '');
   }
 
+  if (deconstructOptions?.allowSubPaths === true) {
+    if (trailingSlash === true) {
+      path = `${path}(.*)`;
+    } else {
+      path = `${path}/(.*)`;
+    }
+  }
+
   return path;
 };
 
@@ -294,11 +304,17 @@ export const constructPathAndMaybeEncode = <
 >(
   urlParams: Record<string, string | boolean | number>,
   urlParamsSchema: S,
-  options: Omit<TSURLOptions<readonly never[]>, 'queryParams'>
+  options: Omit<TSURLOptions<readonly never[]>, 'queryParams'>,
+  deconstructOptions?: DeconstructOptions
 ) => {
   const { encode } = options;
 
-  let path = constructPath(urlParams, urlParamsSchema, options);
+  let path = constructPath(
+    urlParams,
+    urlParamsSchema,
+    options,
+    deconstructOptions
+  );
 
   if (encode === true) {
     path = encodeurl(path);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,7 @@ import {
 
 export const serializeValue = <T extends string>(
   part: AnyPart<T>,
-  value: string | undefined | ReadonlyArray<string>
+  value: string | undefined | readonly string[]
 ) => {
   if (part instanceof RequiredString && typeof value === 'string') {
     return value;
@@ -177,7 +177,7 @@ export const serializeValue = <T extends string>(
 export const serializeURLParams = <
   S extends URLParamsSchema = readonly never[]
 >(
-  params: Record<string, string | undefined | null | ReadonlyArray<string>>,
+  params: Record<string, string | undefined | null | readonly string[]>,
   schema: S
 ) => {
   const serializedParams: Record<
@@ -213,7 +213,7 @@ export const serializeURLParams = <
 export const serializeQueryParams = <
   Q extends QueryParamsSchema = readonly never[]
 >(
-  params: Record<string, string | undefined | null | ReadonlyArray<string>>,
+  params: Record<string, string | undefined | null | readonly string[]>,
   schema: Q
 ) => {
   const serializedParams: Record<

--- a/tests/allow-sub-paths.ts
+++ b/tests/allow-sub-paths.ts
@@ -1,0 +1,44 @@
+import createTSURL, { requiredString } from '../src';
+
+describe('allowSubPaths', () => {
+  it('should allow deconstructing a URL or path that matches the schema, but with additional sub-paths', () => {
+    const url1 = createTSURL(['user', requiredString('userId')], {
+      baseURL: 'https://example.com',
+      basePath: '/api',
+    });
+
+    expect(() =>
+      url1.deconstruct('https://example.com/api/user/123/posts/456')
+    ).toThrow(/invalid\sfor\stemplate/);
+    expect(
+      url1.deconstruct('https://example.com/api/user/123/posts/456', {
+        allowSubPaths: true,
+      })
+    ).toEqual({
+      urlParams: {
+        userId: '123',
+      },
+      queryParams: {},
+    });
+
+    const url2 = createTSURL(['user', requiredString('userId')], {
+      baseURL: 'https://example.com',
+      basePath: '/api',
+      trailingSlash: true,
+    });
+
+    expect(() =>
+      url2.deconstruct('https://example.com/api/user/123/posts/456')
+    ).toThrow(/invalid\sfor\stemplate/);
+    expect(
+      url2.deconstruct('https://example.com/api/user/123/posts/456', {
+        allowSubPaths: true,
+      })
+    ).toEqual({
+      urlParams: {
+        userId: '123',
+      },
+      queryParams: {},
+    });
+  });
+});

--- a/tests/params.ts
+++ b/tests/params.ts
@@ -153,7 +153,7 @@ describe('params', () => {
       }
     );
 
-    // @tsassert: (urlParams: { required: string; } & {} & {} & { optional?: string | undefined; } & {} & {} & {}, queryParams: { requiredQ: string; } & {} & {} & { optionalQ?: string | undefined; } & {} & {} & {} & {} & {} & {} & {} & {}) => string
+    // @tsassert: (urlParams: { required: string; } & { optional?: string | undefined; }, queryParams: { requiredQ: string; } & { optionalQ?: string | undefined; }) => string
     const constructPath = url.constructPath;
 
     expect(constructPath({ required: 'a' }, { requiredQ: 'c' })).toBe(
@@ -166,7 +166,7 @@ describe('params', () => {
       )
     ).toBe('/api/example/a/test/b?optionalQ=d&requiredQ=c');
 
-    // @tsassert: (url: string) => { urlParams: { required: string; } & {} & {} & { optional?: string | undefined; } & {} & {} & {}; queryParams: { requiredQ: string; } & {} & {} & { optionalQ?: string | undefined; } & ... 7 more ... & {}; }
+    // @tsassert: (url: string, deconstructOptions?: DeconstructOptions | undefined) => { urlParams: { required: string; } & { optional?: string | undefined; }; queryParams: { requiredQ: string; } & { optionalQ?: string | undefined; }; }
     const deconstruct = url.deconstruct;
 
     expect(deconstruct('/api/example/a/test?requiredQ=c')).toEqual({
@@ -206,7 +206,7 @@ describe('params', () => {
       }
     );
 
-    // @tsassert: (urlParams: {} & { required: number; } & {} & {} & { optional?: number | undefined; } & {} & {}, queryParams: {} & { requiredQ: number; } & {} & {} & { optionalQ?: number | undefined; } & {} & {} & {} & {} & {} & {} & {}) => string
+    // @tsassert: (urlParams: { required: number; } & { optional?: number | undefined; }, queryParams: { requiredQ: number; } & { optionalQ?: number | undefined; }) => string
     const constructPath = url.constructPath;
 
     expect(constructPath({ required: 1 }, { requiredQ: 3 })).toBe(
@@ -219,7 +219,7 @@ describe('params', () => {
       )
     ).toBe('/api/example/1/test/2?optionalQ=4&requiredQ=3');
 
-    // @tsassert: (url: string) => { urlParams: {} & { required: number; } & {} & {} & { optional?: number | undefined; } & {} & {}; queryParams: {} & { requiredQ: number; } & {} & {} & { optionalQ?: number | undefined; } & ... 6 more ... & {}; }
+    // @tsassert: (url: string, deconstructOptions?: DeconstructOptions | undefined) => { urlParams: { required: number; } & { optional?: number | undefined; }; queryParams: { requiredQ: number; } & { optionalQ?: number | undefined; }; }
     const deconstruct = url.deconstruct;
 
     expect(deconstruct('/api/example/1/test?requiredQ=3')).toEqual({
@@ -262,7 +262,7 @@ describe('params', () => {
       }
     );
 
-    // @tsassert: (urlParams: {} & {} & { required: boolean; } & {} & {} & { optional?: boolean | undefined; } & {}, queryParams: {} & {} & { requiredQ: boolean; } & {} & {} & { optionalQ?: boolean | undefined; } & {} & ... 4 more ... & {}) => string
+    // @tsassert: (urlParams: { required: boolean; } & { optional?: boolean | undefined; }, queryParams: { requiredQ: boolean; } & { optionalQ?: boolean | undefined; }) => string
     const constructPath = url.constructPath;
 
     expect(constructPath({ required: true }, { requiredQ: true })).toBe(
@@ -275,7 +275,7 @@ describe('params', () => {
       )
     ).toBe('/api/example/true/test/false?optionalQ=false&requiredQ=true');
 
-    // @tsassert: (url: string) => { urlParams: {} & {} & { required: boolean; } & {} & {} & { optional?: boolean | undefined; } & {}; queryParams: {} & {} & { requiredQ: boolean; } & {} & {} & { optionalQ?: boolean | undefined; } & ... 5 more ... & {}; }
+    // @tsassert: (url: string, deconstructOptions?: DeconstructOptions | undefined) => { urlParams: { required: boolean; } & { optional?: boolean | undefined; }; queryParams: { requiredQ: boolean; } & { optionalQ?: boolean | undefined; }; }
     const deconstruct = url.deconstruct;
 
     expect(deconstruct('/api/example/true/test?requiredQ=true')).toEqual({
@@ -310,7 +310,7 @@ describe('params', () => {
       ],
     });
 
-    // @tsassert: (urlParams: {} & {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & { requiredQ: readonly string[]; } & {} & {} & { optionalQ?: readonly string[] | undefined; } & {} & {}) => string
+    // @tsassert: (urlParams: {} & {}, queryParams: { requiredQ: readonly string[]; } & { optionalQ?: readonly string[] | undefined; }) => string
     const constructPath1 = url1.constructPath;
 
     expect(constructPath1({}, { requiredQ: ['a', 'b'] })).toBe(
@@ -320,7 +320,7 @@ describe('params', () => {
       constructPath1({}, { requiredQ: ['a', 'b'], optionalQ: ['c', 'd'] })
     ).toBe('/api/example?optionalQ=c&optionalQ=d&requiredQ=a&requiredQ=b');
 
-    // @tsassert: (url: string) => { urlParams: {} & {} & {} & {} & {} & {} & {}; queryParams: {} & {} & {} & {} & {} & {} & { requiredQ: readonly string[]; } & {} & {} & { optionalQ?: readonly string[] | undefined; } & {} & {}; }
+    // @tsassert: (url: string, deconstructOptions?: DeconstructOptions | undefined) => { urlParams: {} & {}; queryParams: { requiredQ: readonly string[]; } & { optionalQ?: readonly string[] | undefined; }; }
     const deconstruct1 = url1.deconstruct;
 
     expect(deconstruct1('/api/example?requiredQ=a&requiredQ=b')).toEqual({
@@ -350,7 +350,7 @@ describe('params', () => {
       queryArrayFormat: 'comma',
     });
 
-    // @tsassert: (urlParams: {} & {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & { requiredQ: readonly string[]; } & {} & {} & { optionalQ?: readonly string[] | undefined; } & {} & {}) => string
+    // @tsassert: (urlParams: {} & {}, queryParams: { requiredQ: readonly string[]; } & { optionalQ?: readonly string[] | undefined; }) => string
     const constructPath2 = url2.constructPath;
 
     expect(constructPath2({}, { requiredQ: ['a', 'b'] })).toBe(
@@ -360,7 +360,7 @@ describe('params', () => {
       constructPath2({}, { requiredQ: ['a', 'b'], optionalQ: ['c', 'd'] })
     ).toBe('/api/example?optionalQ=c,d&requiredQ=a,b');
 
-    // @tsassert: (url: string) => { urlParams: {} & {} & {} & {} & {} & {} & {}; queryParams: {} & {} & {} & {} & {} & {} & { requiredQ: readonly string[]; } & {} & {} & { optionalQ?: readonly string[] | undefined; } & {} & {}; }
+    // @tsassert: (url: string, deconstructOptions?: DeconstructOptions | undefined) => { urlParams: {} & {}; queryParams: { requiredQ: readonly string[]; } & { optionalQ?: readonly string[] | undefined; }; }
     const deconstruct2 = url2.deconstruct;
 
     expect(deconstruct2('/api/example?requiredQ=a,b')).toEqual({
@@ -387,7 +387,7 @@ describe('params', () => {
       ],
     });
 
-    // @tsassert: (urlParams: {} & {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly number[]; } & {} & {} & { optionalQ?: readonly number[] | undefined; } & {}) => string
+    // @tsassert: (urlParams: {} & {}, queryParams: { requiredQ: readonly number[]; } & { optionalQ?: readonly number[] | undefined; }) => string
     const constructPath1 = url1.constructPath;
 
     expect(constructPath1({}, { requiredQ: [1, 2] })).toBe(
@@ -397,7 +397,7 @@ describe('params', () => {
       '/api/example?optionalQ=3&optionalQ=4&requiredQ=1&requiredQ=2'
     );
 
-    // @tsassert: (url: string) => { urlParams: {} & {} & {} & {} & {} & {} & {}; queryParams: {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly number[]; } & {} & {} & { optionalQ?: readonly number[] | undefined; } & {}; }
+    // @tsassert: (url: string, deconstructOptions?: DeconstructOptions | undefined) => { urlParams: {} & {}; queryParams: { requiredQ: readonly number[]; } & { optionalQ?: readonly number[] | undefined; }; }
     const deconstruct1 = url1.deconstruct;
 
     expect(deconstruct1('/api/example?requiredQ=1&requiredQ=2')).toEqual({
@@ -427,7 +427,7 @@ describe('params', () => {
       queryArrayFormat: 'comma',
     });
 
-    // @tsassert: (urlParams: {} & {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly number[]; } & {} & {} & { optionalQ?: readonly number[] | undefined; } & {}) => string
+    // @tsassert: (urlParams: {} & {}, queryParams: { requiredQ: readonly number[]; } & { optionalQ?: readonly number[] | undefined; }) => string
     const constructPath2 = url2.constructPath;
 
     expect(constructPath2({}, { requiredQ: [1, 2] })).toBe(
@@ -437,7 +437,7 @@ describe('params', () => {
       '/api/example?optionalQ=3,4&requiredQ=1,2'
     );
 
-    // @tsassert: (url: string) => { urlParams: {} & {} & {} & {} & {} & {} & {}; queryParams: {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly number[]; } & {} & {} & { optionalQ?: readonly number[] | undefined; } & {}; }
+    // @tsassert: (url: string, deconstructOptions?: DeconstructOptions | undefined) => { urlParams: {} & {}; queryParams: { requiredQ: readonly number[]; } & { optionalQ?: readonly number[] | undefined; }; }
     const deconstruct2 = url2.deconstruct;
 
     expect(deconstruct2('/api/example?requiredQ=1,2')).toEqual({
@@ -464,7 +464,7 @@ describe('params', () => {
       ],
     });
 
-    // @tsassert: (urlParams: {} & {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly boolean[]; } & {} & {} & { optionalQ?: readonly boolean[] | undefined; }) => string
+    // @tsassert: (urlParams: {} & {}, queryParams: { requiredQ: readonly boolean[]; } & { optionalQ?: readonly boolean[] | undefined; }) => string
     const constructPath1 = url1.constructPath;
 
     expect(constructPath1({}, { requiredQ: [true, false] })).toBe(
@@ -476,7 +476,7 @@ describe('params', () => {
       '/api/example?optionalQ=true&optionalQ=false&requiredQ=true&requiredQ=false'
     );
 
-    // @tsassert: (url: string) => { urlParams: {} & {} & {} & {} & {} & {} & {}; queryParams: {} & {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly boolean[]; } & {} & {} & { optionalQ?: readonly boolean[] | undefined; }; }
+    // @tsassert: (url: string, deconstructOptions?: DeconstructOptions | undefined) => { urlParams: {} & {}; queryParams: { requiredQ: readonly boolean[]; } & { optionalQ?: readonly boolean[] | undefined; }; }
     const deconstruct1 = url1.deconstruct;
 
     expect(deconstruct1('/api/example?requiredQ=true&requiredQ=false')).toEqual(
@@ -508,7 +508,7 @@ describe('params', () => {
       queryArrayFormat: 'comma',
     });
 
-    // @tsassert: (urlParams: {} & {} & {} & {} & {} & {} & {}, queryParams: {} & {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly boolean[]; } & {} & {} & { optionalQ?: readonly boolean[] | undefined; }) => string
+    // @tsassert: (urlParams: {} & {}, queryParams: { requiredQ: readonly boolean[]; } & { optionalQ?: readonly boolean[] | undefined; }) => string
     const constructPath2 = url2.constructPath;
 
     expect(constructPath2({}, { requiredQ: [true, false] })).toBe(
@@ -518,7 +518,7 @@ describe('params', () => {
       constructPath2({}, { requiredQ: [true, false], optionalQ: [true, false] })
     ).toBe('/api/example?optionalQ=true,false&requiredQ=true,false');
 
-    // @tsassert: (url: string) => { urlParams: {} & {} & {} & {} & {} & {} & {}; queryParams: {} & {} & {} & {} & {} & {} & {} & {} & { requiredQ: readonly boolean[]; } & {} & {} & { optionalQ?: readonly boolean[] | undefined; }; }
+    // @tsassert: (url: string, deconstructOptions?: DeconstructOptions | undefined) => { urlParams: {} & {}; queryParams: { requiredQ: readonly boolean[]; } & { optionalQ?: readonly boolean[] | undefined; }; }
     const deconstruct2 = url2.deconstruct;
 
     expect(deconstruct2('/api/example?requiredQ=true,false')).toEqual({

--- a/tests/splat.ts
+++ b/tests/splat.ts
@@ -11,10 +11,10 @@ describe('splat', () => {
       }
     );
 
-    // @tsassert: (urlParams: { userId: string; } & {} & {} & {} & {} & {} & { splat?: readonly string[] | undefined; }, queryParams: {} & {} & {} & {} & {} & {} & {} & {} & {} & {} & {} & {}) => string
+    // @tsassert: (urlParams: { userId: string; } & { splat?: readonly string[] | undefined; }, queryParams: {} & {}) => string
     const constructPath = url.constructPath;
 
-    // @tsassert: (url: string) => { urlParams: { userId: string; } & {} & {} & {} & {} & {} & { splat?: readonly string[] | undefined; }; queryParams: {} & {} & {} & {} & {} & {} & {} & {} & {} & {} & {} & {}; }
+    // @tsassert: (url: string, deconstructOptions?: DeconstructOptions | undefined) => { urlParams: { userId: string; } & { splat?: readonly string[] | undefined; }; queryParams: {} & {}; }
     const deconstruct = url.deconstruct;
 
     expect(constructPath({ userId: '123' }, {})).toBe('/api/user/123');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "noUncheckedIndexedAccess": true,
+    "noErrorTruncation": true,
     "moduleResolution": "node",
     "jsx": "react",
     "target": "es6",


### PR DESCRIPTION
Add an `{allowSubPaths: true}` option to the deconstruct method.

This allows deconstructing URLs/paths where they match the template but include additional sub-paths e.g.

```ts
const url = createTSURL(['user', requiredString('userId')], {
  baseUrl: 'https://server.com',
  basePath: '/api',
  trailingSlash: false,
});

url.deconstruct('https://server.com/api/user/123/posts/123');
// throws an error

url.deconstruct('https://server.com/api/user/123/posts/123', {
  allowSubPaths: true,
});
// returns { urlParams: { userId: '123' }, queryParams: {} }
```

This PR also converts `ReadonlyArray<whatever>` to `readonly whatever[]` and makes some changes to how param types are inferred so that instead of inferring a LOT of interfaces (one for each value type: string, number, boolean, etc) we only infer a single interface for required parts and another for optional parts.

This means that instead of ending up with types like `{ requiredString: string } & { requiredNumber: number } & {} & {} & {} & {}... etc { optionalNumber: number } & {}` . We just end up with `{ requiredString: string, requiredNumber: number } & { optionalNumber: number }`

Some minor fixes to documentation.