### PR TITLE
Fix allow sub-paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jakesidsmith/tsurl",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jakesidsmith/tsurl",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "@types/decode-uri-component": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakesidsmith/tsurl",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Type safe URL construction and deconstruction",
   "main": "dist/index.js",
   "scripts": {

--- a/src/tsurl.ts
+++ b/src/tsurl.ts
@@ -98,14 +98,15 @@ export class TSURL<
     const pathTemplate = constructPathAndMaybeEncode(
       this.getURLParams(),
       this.schema,
-      this.options,
-      deconstructOptions
+      this.options
     );
     const parsed = urlParse(this.options.decode ? decodeUrl(url) : url, false);
 
     const urlMatch = match<
       Record<string, string | undefined | null | readonly string[]>
-    >(pathTemplate)(parsed.pathname);
+    >(pathTemplate, {
+      end: !deconstructOptions?.allowSubPaths,
+    })(parsed.pathname);
 
     if (!urlMatch) {
       throw new Error(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,6 @@ import {
 } from './params';
 import {
   AnyPart,
-  DeconstructOptions,
   InferQueryParams,
   InferURLParams,
   QueryParamsSchema,
@@ -247,8 +246,7 @@ export const serializeQueryParams = <
 export const constructPath = <S extends URLParamsSchema = readonly never[]>(
   urlParams: Record<string, string | boolean | number | readonly string[]>,
   urlParamsSchema: S,
-  options: Omit<TSURLOptions<readonly never[]>, 'queryParams'>,
-  deconstructOptions?: DeconstructOptions
+  options: Omit<TSURLOptions<readonly never[]>, 'queryParams'>
 ) => {
   const { trailingSlash, normalize } = options;
 
@@ -288,14 +286,6 @@ export const constructPath = <S extends URLParamsSchema = readonly never[]>(
     path = path.replace(MATCHES_MAYBE_TRAILING_SLASH, '');
   }
 
-  if (deconstructOptions?.allowSubPaths === true) {
-    if (trailingSlash === true) {
-      path = `${path}(.*)`;
-    } else {
-      path = `${path}/(.*)`;
-    }
-  }
-
   return path;
 };
 
@@ -304,17 +294,11 @@ export const constructPathAndMaybeEncode = <
 >(
   urlParams: Record<string, string | boolean | number>,
   urlParamsSchema: S,
-  options: Omit<TSURLOptions<readonly never[]>, 'queryParams'>,
-  deconstructOptions?: DeconstructOptions
+  options: Omit<TSURLOptions<readonly never[]>, 'queryParams'>
 ) => {
   const { encode } = options;
 
-  let path = constructPath(
-    urlParams,
-    urlParamsSchema,
-    options,
-    deconstructOptions
-  );
+  let path = constructPath(urlParams, urlParamsSchema, options);
 
   if (encode === true) {
     path = encodeurl(path);

--- a/tests/allow-sub-paths.ts
+++ b/tests/allow-sub-paths.ts
@@ -20,6 +20,16 @@ describe('allowSubPaths', () => {
       },
       queryParams: {},
     });
+    expect(
+      url1.deconstruct('https://example.com/api/user/123', {
+        allowSubPaths: true,
+      })
+    ).toEqual({
+      urlParams: {
+        userId: '123',
+      },
+      queryParams: {},
+    });
 
     const url2 = createTSURL(['user', requiredString('userId')], {
       baseURL: 'https://example.com',


### PR DESCRIPTION
Now allows trailing slashes in URLs/paths without a sub-path by using path-to-regexp "end" option